### PR TITLE
fix: move stylelint-webpack-plugin to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "author": "Daniel Brüggemann",
   "license": "MIT",
   "devDependencies": {
-    "stylelint": "^9.4.0",
+    "stylelint": "^9.4.0"
+  },
+  "dependencies": {
     "stylelint-webpack-plugin": "^0.10.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
`stylelint-webpack-plugin` will be installed properly.

No more "Error: Cannot find module 'stylelint-webpack-plugin'"